### PR TITLE
Fix pressing cancel on get_integer still returns status 1

### DIFF
--- a/DlgModule/MacOSX/dlgmodule.mm
+++ b/DlgModule/MacOSX/dlgmodule.mm
@@ -625,18 +625,18 @@ namespace dialog_module {
 
     string str_str = str;
     string str_def = remove_trailing_zeros(def);
-	char* stringResult = cocoa_input_box(str_str.c_str(), str_def.c_str(), current_icon.c_str(), (caption == "") ? "Input Query" : caption.c_str(), true);
-	if (stringResult[0] != '\0')
-	{
-		double result = strtod(stringResult, nullptr);
+    const char* stringResult = cocoa_input_box(str_str.c_str(), str_def.c_str(), current_icon.c_str(), (caption == "") ? "Input Query" : caption.c_str(), true);
+    if (stringResult[0] != '\0')
+    {
+        double result = strtod(stringResult, nullptr);
 
-		if (result < DIGITS_MIN) result = DIGITS_MIN;
-		if (result > DIGITS_MAX) result = DIGITS_MAX;
+        if (result < DIGITS_MIN) result = DIGITS_MIN;
+        if (result > DIGITS_MAX) result = DIGITS_MAX;
 
-		return result;
-	}
-	else
-		return nan(""); // User clicked cancel or didn't enter any number.
+        return result;
+    }
+    else
+        return nan(""); // User clicked cancel or didn't enter any number.
   }
   
   double get_passcode(char *str, double def) {

--- a/DlgModule/MacOSX/dlgmodule.mm
+++ b/DlgModule/MacOSX/dlgmodule.mm
@@ -625,12 +625,18 @@ namespace dialog_module {
 
     string str_str = str;
     string str_def = remove_trailing_zeros(def);
-    double result = strtod(cocoa_input_box(str_str.c_str(), str_def.c_str(), current_icon.c_str(), (caption == "") ? "Input Query" : caption.c_str(), true), nullptr);
+	char* stringResult = cocoa_input_box(str_str.c_str(), str_def.c_str(), current_icon.c_str(), (caption == "") ? "Input Query" : caption.c_str(), true);
+	if (stringResult[0] != '\0')
+	{
+		double result = strtod(stringResult, nullptr);
 
-    if (result < DIGITS_MIN) result = DIGITS_MIN;
-    if (result > DIGITS_MAX) result = DIGITS_MAX;
+		if (result < DIGITS_MIN) result = DIGITS_MIN;
+		if (result > DIGITS_MAX) result = DIGITS_MAX;
 
-    return result;
+		return result;
+	}
+	else
+		return nan(""); // User clicked cancel or didn't enter any number.
   }
   
   double get_passcode(char *str, double def) {

--- a/DlgModule/Universal/dlgmodule.cpp
+++ b/DlgModule/Universal/dlgmodule.cpp
@@ -179,8 +179,8 @@ void get_integer_threaded(char *str, double def, unsigned id) {
   double result = get_integer(str, def);
   int resultMap = CreateDsMap(0);
   DsMapAddDouble(resultMap, (char *)"id", id);
-  DsMapAddDouble(resultMap, (char *)"status", 1);
-  DsMapAddDouble(resultMap, (char *)"value", result);
+  DsMapAddDouble(resultMap, (char *)"status", isnan(result) ? 0 : 1);
+  DsMapAddDouble(resultMap, (char *)"value", isnan(result) ? 0 : result);
   CreateAsynEventWithDSMap(resultMap, 63);
   enable_dialog_creation = true;
 }

--- a/DlgModule/Win32/dlgmodule.cpp
+++ b/DlgModule/Win32/dlgmodule.cpp
@@ -636,12 +636,18 @@ namespace dialog_module {
       if (def > DIGITS_MAX) def = DIGITS_MAX;
 
       string cpp_tdef = remove_trailing_zeros(def);
-      double result = strtod(get_string_helper(str, (char *)cpp_tdef.c_str(), hide), nullptr);
+      char* stringResult = get_string_helper(str, (char*)cpp_tdef.c_str(), hide);
+      if (stringResult[0] != '\0')
+      {
+          double result = strtod(stringResult, nullptr);
 
-      if (result < DIGITS_MIN) result = DIGITS_MIN;
-      if (result > DIGITS_MAX) result = DIGITS_MAX;
+          if (result < DIGITS_MIN) result = DIGITS_MIN;
+          if (result > DIGITS_MAX) result = DIGITS_MAX;
 
-      return result;
+          return result;
+      }
+      else
+          return nan(""); // User clicked cancel or didn't enter any number.
     }
     #endif
 


### PR DESCRIPTION
This caused some headaches for me. Status for get_integer_async() always returned 1 regardless of whether the user clicked OK or cancel.  No way to differentiate the user clicking cancel, or the user deliberately typing in 0 and clicking OK, leading to many potential bugs in the host program.

Fix is for windows only, need help implementing for the other platforms since I didn't quite grasp the file structure for mac, the mac folder doesn't contain a dlgmodule.cpp like windows and xlib, as far as I can see.